### PR TITLE
Add topics table to database

### DIFF
--- a/priv/repo/migrations/20180925115106_add_topics_table.exs
+++ b/priv/repo/migrations/20180925115106_add_topics_table.exs
@@ -1,0 +1,9 @@
+defmodule Discuss.Repo.Migrations.AddTopicsTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:topics) do
+      add :title, :string
+    end
+  end
+end


### PR DESCRIPTION
Create migration to add the `topics` table on database.
The table consists of:

| id | title |
--------------
| `integer` | `string` |